### PR TITLE
Bump Glade version to 3.20.2 for CPU bugfix and Platform to stable

### DIFF
--- a/org.gnome.Glade.json
+++ b/org.gnome.Glade.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Glade",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.24",
+    "runtime-version": "3.26",
     "sdk": "org.gnome.Sdk",
     "command": "glade",
     "rename-desktop-file": "glade.desktop",
@@ -33,8 +33,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/glade/3.20/glade-3.20.0.tar.xz",
-                    "sha256": "82d96dca5dec40ee34e2f41d49c13b4ea50da8f32a3a49ca2da802ff14dc18fe"
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/glade/3.20/glade-3.20.2.tar.xz",
+                    "sha256": "07d1545570951aeded20e9fdc6d3d8a56aeefe2538734568c5335be336c6abed"
                 }
             ]
         }


### PR DESCRIPTION
Glade on Flathub is still on 3.20.0, while 3.20.2 has a number of important bugfixes. This bumps the Glade (and Platform while I'm here) version to latest stable.