### PR TITLE
Add the libhandy 0.0.9 catalog

### DIFF
--- a/org.gnome.Glade.json
+++ b/org.gnome.Glade.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Glade",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.28",
+    "runtime-version": "3.32",
     "sdk": "org.gnome.Sdk",
     "command": "glade",
     "rename-desktop-file": "glade.desktop",
@@ -35,6 +35,24 @@
                     "type": "archive",
                     "url": "http://ftp.gnome.org/pub/GNOME/sources/glade/3.22/glade-3.22.1.tar.xz",
                     "sha256": "dff89a2ef2eaf000ff2a46979978d03cb9202cb04668e01d0ea5c5bb5547e39a"
+                }
+            ]
+        },
+        {
+            "name" : "libhandy",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "-Dexamples=false",
+                "-Dglade_catalog=enabled",
+                "-Dintrospection=disabled",
+                "-Dtests=false",
+                "-Dvapi=false"
+            ],
+            "sources" : [
+                {
+                    "type": "archive",
+                    "url": "https://source.puri.sm/Librem5/libhandy/-/archive/v0.0.9/libhandy-v0.0.9.tar.gz",
+                    "sha256": "a9f3c06eaa482efabc1d00dd2df65dc7d41253a71c0cb0402328a831a4f398a3"
                 }
             ]
         }


### PR DESCRIPTION
Also bump the runtime to 3.30 as libhandy needs a version of Meson with
support for features.

libhandy 0.0.9 is the recommended libhandy version for GNOME 3.32.