### PR TITLE
Update to 1.8.2 and add x-checker-data for libhandy

### DIFF
--- a/org.gnome.Glade.json
+++ b/org.gnome.Glade.json
@@ -50,8 +50,8 @@
             "sources" : [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libhandy/1.6/libhandy-1.6.2.tar.xz",
-                    "sha256": "7fa89aaa87966b6d0f5f4ef4d3efdaf654e2b01ea2c7ce2bd70301d1f9f42ca3"
+                    "url": "https://download.gnome.org/sources/libhandy/1.8/libhandy-1.8.2.tar.xz",
+                    "sha256": "d11aa2cd3e570ac6d0efdba46d173147c11f45826457e924c05990bb2e0df9ad"
                 }
             ]
         }

--- a/org.gnome.Glade.json
+++ b/org.gnome.Glade.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.gnome.Glade",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "44",
+    "runtime-version" : "45",
     "sdk" : "org.gnome.Sdk",
     "command" : "glade",
     "finish-args" : [

--- a/org.gnome.Glade.json
+++ b/org.gnome.Glade.json
@@ -51,7 +51,12 @@
                 {
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/libhandy/1.8/libhandy-1.8.2.tar.xz",
-                    "sha256": "d11aa2cd3e570ac6d0efdba46d173147c11f45826457e924c05990bb2e0df9ad"
+                    "sha256": "d11aa2cd3e570ac6d0efdba46d173147c11f45826457e924c05990bb2e0df9ad",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "libhandy",
+                        "stable-only": true
+                    }
                 }
             ]
         }


### PR DESCRIPTION
~(edit) Apparently the [screenshot source](https://glade.gnome.org/images/glade-main-page.png) went down a while ago so I'm using the Wayback Machine now. I don't know if I should just host it in the git repo but whatever, it works.~
Moved to #23

Also remove empty .gitmodules.