### PR TITLE
Use Wayback Machine (or other better source) for screenshot

### DIFF
--- a/org.gnome.Glade.json
+++ b/org.gnome.Glade.json
@@ -34,6 +34,10 @@
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/glade/3.40/glade-3.40.0.tar.xz",
                     "sha256": "31c9adaea849972ab9517b564e19ac19977ca97758b109edc3167008f53e3d9c"
+                },
+                {
+                    "type": "patch",
+                    "path": "wayback-machine-screenshot.patch"
                 }
             ]
         },

--- a/wayback-machine-screenshot.patch
+++ b/wayback-machine-screenshot.patch
@@ -1,0 +1,13 @@
+diff --git a/data/org.gnome.Glade.appdata.xml.in b/data/org.gnome.Glade.appdata.xml.in
+index b9286a00..8da2ee5a 100644
+--- a/data/org.gnome.Glade.appdata.xml.in
++++ b/data/org.gnome.Glade.appdata.xml.in
+@@ -29,7 +29,7 @@
+   </description>
+   <screenshots>
+     <screenshot type="default">
+-      <image>https://glade.gnome.org/images/glade-main-page.png</image>
++      <image>https://web.archive.org/web/20230307214142id_/https://glade.gnome.org/images/glade-main-page.png</image>
+     </screenshot>
+   </screenshots>
+   <provides>


### PR DESCRIPTION
[glade.gnome.org](https://glade.gnome.org/) is currently a non-configured nginx server, and not serving the screenshot referenced in the metainfo. This PR uses the Wayback Machine, or a better source (though I haven't found any).